### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [0.8.0] - 2025-03-26
+
 ### Changed
 
 - [BREAKING] Updated `windows` dependency to `0.61`
@@ -76,7 +78,8 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/wnf/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/wnf/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/matthias-stemmler/wnf/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/matthias-stemmler/wnf/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/matthias-stemmler/wnf/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/matthias-stemmler/wnf/compare/v0.5.1...v0.5.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "wnf"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2021"
 rust-version = "1.74" # should be the same as in devutils, docs and MSRV job

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ table of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-wnf = "0.7.0"
+wnf = "0.8.0"
 ```
 
 Some functionality of this crate is only available if the corresponding
@@ -31,7 +31,7 @@ the `subscribe` feature:
 
 ```toml
 [dependencies]
-wnf = { version = "0.7.0", features = ["subscribe"] }
+wnf = { version = "0.8.0", features = ["subscribe"] }
 ```
 
 This is a Windows-only crate and will fail to compile on other platforms. If you target multiple platforms, it is
@@ -40,7 +40,7 @@ recommended that you declare it as a
 
 ```toml
 [target.'cfg(windows)'.dependencies]
-wnf = "0.7.0"
+wnf = "0.8.0"
 ```
 
 ## Usage

--- a/crates-io.md
+++ b/crates-io.md
@@ -22,7 +22,7 @@ table of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-wnf = "0.7.0"
+wnf = "0.8.0"
 ```
 
 Some functionality of this crate is only available if the corresponding
@@ -31,7 +31,7 @@ Some functionality of this crate is only available if the corresponding
 
 ```toml
 [dependencies]
-wnf = { version = "0.7.0", features = ["subscribe"] }
+wnf = { version = "0.8.0", features = ["subscribe"] }
 ```
 
 This is a Windows-only crate and will fail to compile on other platforms. If you target multiple platforms, it is
@@ -40,7 +40,7 @@ recommended that you declare it as a
 
 ```toml
 [target.'cfg(windows)'.dependencies]
-wnf = "0.7.0"
+wnf = "0.8.0"
 ```
 
 ## Usage
@@ -79,5 +79,5 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[examples]: https://github.com/matthias-stemmler/wnf/tree/v0.7.0/examples
-[docs]: https://docs.rs/wnf/0.7.0/wnf/
+[examples]: https://github.com/matthias-stemmler/wnf/tree/v0.8.0/examples
+[docs]: https://docs.rs/wnf/0.8.0/wnf/

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "versionBumpLevel": "minor"
+  "versionBumpLevel": "none"
 }


### PR DESCRIPTION
## [0.8.0] - 2025-03-26

### Changed

- [BREAKING] Updated `windows` dependency to `0.61`